### PR TITLE
streamlined mediation test function

### DIFF
--- a/odima.R
+++ b/odima.R
@@ -13,24 +13,32 @@ permuteDist = function(d){
   as.dist(d[p,p])
 }
 
-pdCorMediationTest = function(exposure, mediator, response, nrep){
-  if (is.null(nrep))
+pdCorMediationTest = function(exposure, mediator, response, nrep=NULL){
+  method <- "WARNING:Specify the number of replicates nrep>0 to perform the test"
+  if (!is.null(nrep)){
+    nrep <- floor(nrep)
+    if (nrep <1)
+      nrep <- 0
+    if (nrep > 0)
+      method <- "pdCor mediation test of independence of mediator and response removing exposure"
+  }
+  else {
     nrep <- 0
+  }
   if(bcdcor(exposure, mediator)< pdcor(mediator, response, exposure)){
     S <- replicate(nrep,expr = bcdcor(permuteDist(exposure),mediator)*pdcor(mediator, response, exposure))
   }
   else{
     S <- replicate(nrep, expr = bcdcor(exposure,mediator)*pdcor(mediator, permuteDist(response), exposure))
   }
-  mediationTest <- (1+sum(S>mediationStat(exposure, mediator, response)))/(nrep+1)
+  p.value <- ifelse( nrep>0, ((1+sum(S>mediationStat(exposure, mediator, response)))/(nrep+1)), 1)
   dataname <- paste("replicates ", nrep, sep = "")
-  method <- ifelse(nrep > 0, "pdCor mediation test of independence of mediator and response removing exposure", "WARNING:Specify the number of replicates nrep>0 to perform the test")
   bcdcor_estimates <- c(bcdcor(exposure, mediator)[1], bcdcor(exposure, response), bcdcor(mediator, response)#, pdcor(distjsd_early, dR_early, dE_early)
                         )
     e <- list(method = method, 
             statistic = mediationStat(exposure, mediator, response), 
             estimates = bcdcor_estimates,
-            p.value = mediationTest,
+            p.value = p.value,
             replicates = nrep,
             data.name = dataname)
   class(e) <- "htest"

--- a/odima.R
+++ b/odima.R
@@ -1,7 +1,9 @@
 mediationStat = function(exposure, mediator, response){
   EM = bcdcor(exposure, mediator)
   MRE = pdcor(mediator, response, exposure)
-  EM*MRE
+  mediationStat <- EM*MRE
+  attr(mediationStat, "names") <- "MediationStat"
+  return(mediationStat)
 }
 
 permuteDist = function(d){
@@ -12,13 +14,27 @@ permuteDist = function(d){
 }
 
 pdCorMediationTest = function(exposure, mediator, response, nrep=99999){
+  if (is.null(nrep))
+    nrep <- 0
   if(bcdcor(exposure, mediator)< pdcor(mediator, response, exposure)){
-    S = replicate(nrep,expr = bcdcor(permuteDist(exposure),mediator)*pdcor(mediator, response, exposure))
+    S <- replicate(nrep,expr = bcdcor(permuteDist(exposure),mediator)*pdcor(mediator, response, exposure))
   }
   else{
-    S = replicate(nrep, expr = bcdcor(exposure,mediator)*pdcor(mediator, permuteDist(response), exposure))
+    S <- replicate(nrep, expr = bcdcor(exposure,mediator)*pdcor(mediator, permuteDist(response), exposure))
   }
-  (1+sum(S>mediationStat(exposure, mediator, response)))/(nrep+1)
-}
+  mediationTest <- (1+sum(S>mediationStat(exposure, mediator, response)))/(nrep+1)
+  dataname <- paste("replicates ", nrep, sep = "")
+  method <- ifelse(nrep > 0, "pdCor mediation test of independence of mediator and response removing exposure", "WARNING:Specify the number of replicates nrep>0 to perform the test")
+  bcdcor_estimates <- c(bcdcor(exposure, mediator)[1], bcdcor(exposure, response), bcdcor(mediator, response)#, pdcor(distjsd_early, dR_early, dE_early)
+                        )
+    e <- list(method = method, 
+            statistic = mediationStat(exposure, mediator, response), 
+            estimates = bcdcor_estimates,
+            p.value = mediationTest,
+            replicates = nrep,
+            data.name = dataname)
+  class(e) <- "htest"
+  return(e)
+  }
 
 subset.distance = function(d, sub) as.dist(as.matrix(d)[sub, sub])

--- a/odima.R
+++ b/odima.R
@@ -13,7 +13,7 @@ permuteDist = function(d){
   as.dist(d[p,p])
 }
 
-pdCorMediationTest = function(exposure, mediator, response, nrep=99999){
+pdCorMediationTest = function(exposure, mediator, response, nrep){
   if (is.null(nrep))
     nrep <- 0
   if(bcdcor(exposure, mediator)< pdcor(mediator, response, exposure)){


### PR DESCRIPTION
1. added nrep warning message
2. added rounding down nrep to integer
3. changed = to <- to alleviate assignment issues in some r versions
4. introduced output list of class hlist
5. added three bcdcor() outputs for estimates
